### PR TITLE
refactor: Remove close button on question response message

### DIFF
--- a/src/event/interaction_create.rs
+++ b/src/event/interaction_create.rs
@@ -417,17 +417,18 @@ pub async fn responder(ctx: Context, interaction: Interaction) {
 
             thread
                 .send_message(&ctx, |m| {
-                    m.content( MessageBuilder::new().push_quote(format!("Hey {}! Thank you for raising this — please hang tight as someone from our community may help you out. Meanwhile, feel free to add anymore information in this thread!", user_mention)).build()).components(|c| {
-                        c.create_action_row(|ar| {
-                            ar.create_button(|button| {
-                                button
-                                    .style(ButtonStyle::Success)
-                                    .label("Close")
-                                    .custom_id("gitpod_close_issue")
-                                    .emoji(ReactionType::Unicode("✉️".to_string()))
-                            })
-                        })
-                    })
+                    m.content( MessageBuilder::new().push_quote(format!("Hey {}! Thank you for raising this — please hang tight as someone from our community may help you out. Meanwhile, feel free to add anymore information in this thread!", user_mention)).build())
+					// .components(|c| {
+                    //     c.create_action_row(|ar| {
+                    //         ar.create_button(|button| {
+                    //             button
+                    //                 .style(ButtonStyle::Success)
+                    //                 .label("Close")
+                    //                 .custom_id("gitpod_close_issue")
+                    //                 .emoji(ReactionType::Unicode("✉️".to_string()))
+                    //         })
+                    //     })
+                    // })
                 })
                 .await
                 .unwrap();


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #2 

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
