### PR TITLE
refactor(thread_update): Do not send thread inactivity reminder

### DIFF
--- a/src/event/thread_update.rs
+++ b/src/event/thread_update.rs
@@ -1,17 +1,34 @@
+use regex::Regex;
+use serenity::{http::CacheHttp, model::channel::MessageType};
+
 use super::*;
 
 // Was trying to hook into auto thread archival and ask the participants
 // if the thread was resolved but guess we can't reliably do it now
 // since there is no reliable way to detect who triggered thread_update
-pub async fn responder(_ctx: Context, _thread: GuildChannel) {
-    let thread_type = {
-        if _thread.name.starts_with("✅") || _thread.name.starts_with("❓") {
-            "question"
-        } else {
-            "thread"
-        }
-    };
+// Tl;dr : Discord API doesn't tell you who archived the thread, which is a big issue.
+async fn unarchival_action(_ctx: Context, _thread: GuildChannel) {
+    _thread
+            .say(
+                &_ctx.http,
+                "Whoever is trying to archive from the Discord UI, please send `/close` as a message here instead.",
+            )
+            .await
+            .unwrap();
+    _thread
+        .edit_thread(&_ctx.http, |t| t.archived(false))
+        .await
+        .unwrap();
+}
 
+pub async fn responder(_ctx: Context, _thread: GuildChannel) {
+    // let thread_type = {
+    //     if _thread.name.starts_with("✅") || _thread.name.starts_with("❓") {
+    //         "question"
+    //     } else {
+    //         "thread"
+    //     }
+    // };
     let last_msg = &_ctx
         .http
         .get_messages(*_thread.id.as_u64(), "")
@@ -19,48 +36,19 @@ pub async fn responder(_ctx: Context, _thread: GuildChannel) {
         .unwrap();
     let last_msg = last_msg.first().unwrap();
 
-    let no_activity_message = format!("> This {} did not have any recent activity or wasn't normally closed. Feel free to `/close` it or post an update if anything is unresolved.", thread_type);
-
-    if !last_msg.is_own(&_ctx.cache).await && _thread.thread_metadata.unwrap().archived {
-        _thread
-            .send_message(&_ctx, |m| {
-                m.content(&no_activity_message).components(|c| {
-                    c.create_action_row(|ar| {
-                        ar.create_button(|button| {
-                            button
-                                .style(ButtonStyle::Success)
-                                .label("Close")
-                                .custom_id("gitpod_close_issue")
-                                .emoji(ReactionType::Unicode("✉️".to_string()))
-                        })
-                    })
-                })
-            })
-            .await
-            .unwrap();
-        // let tp = _thread.id.get_thread_members(&_ctx.http).await.unwrap();
-
-        // for mem in tp.iter() {
-        //     dbg!(mem.user_id);
-        // }
-
-        // let stuff_str: String = tp
-        //     .into_iter()
-        //     .map(|i| i.mention().to_string())
-        //     .collect::<String>();
-        // println!("{}", stuff_str);
-
-        // _thread
-        //     .edit_thread(&_ctx, |t| t.archived(true))
-        //     .await
-        //     .unwrap();
-    } else if last_msg.is_own(&_ctx.cache).await
-        && last_msg.content == no_activity_message
-        && _thread.thread_metadata.unwrap().archived
-    {
-        _thread
-            .edit_thread(&_ctx.http, |t| t.archived(false))
-            .await
-            .unwrap();
+    if dbg!(_thread.thread_metadata.unwrap().archived) && dbg!(last_msg.is_own(&_ctx.cache).await) {
+        if last_msg.kind.eq(&MessageType::GroupNameUpdate)
+            || dbg!(
+                Regex::new(format!("^This [a-z]+ was closed ?b?y?").as_str())
+                    .unwrap()
+                    .is_match(dbg!(last_msg.content.as_str()))
+            )
+        {
+            return;
+        } else {
+            unarchival_action(_ctx, _thread).await;
+        }
+    } else if _thread.thread_metadata.unwrap().archived {
+        unarchival_action(_ctx, _thread).await;
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
See relevant discussion: https://discord.com/channels/816244985187008514/949319122397847552/961085224664596510

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #12

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
