### PR TITLE
refactor(message_logging): Set visibility to admins only

### DIFF
--- a/src/event/message_update.rs
+++ b/src/event/message_update.rs
@@ -40,16 +40,16 @@ pub async fn responder(
         let dbnode = Database::from("msgcache".to_string()).await;
         let msg_content = &message.content;
 
-        let mut is_self_reacted = false;
-        for user in message.reactions.iter() {
-            if user.me {
-                is_self_reacted = true;
-            }
-        }
+        // let mut is_self_reacted = false;
+        // for user in message.reactions.iter() {
+        //     if user.me {
+        //         is_self_reacted = true;
+        //     }
+        // }
 
-        if !is_self_reacted && !message.is_own(&_ctx.cache).await {
-            message.react(&_ctx.http, '✍').await.ok();
-        }
+        // if !is_self_reacted && !message.is_own(&_ctx.cache).await {
+        //     message.react(&_ctx.http, '✍').await.ok();
+        // }
         let edit_time = &message.edited_timestamp.unwrap().format("%H:%M:%S %p");
         let old_content = dbnode.fetch_msg(_msg_id).await;
         let new_content = format!(

--- a/src/event/reaction_add.rs
+++ b/src/event/reaction_add.rs
@@ -1,3 +1,4 @@
+use serenity::model::Permissions;
 use substr::StringUtils;
 
 use super::*;
@@ -5,8 +6,9 @@ use super::*;
 pub async fn responder(_ctx: Context, _added_reaction: Reaction) {
     let emoji = &_added_reaction.emoji.to_string();
     let reacted_user = &_added_reaction.user(&_ctx.http).await.unwrap();
-    let a_bot_reacted_now = &reacted_user.bot;
-
+    if reacted_user.bot {
+        return;
+    }
     let react_data = &_added_reaction.message(&_ctx.http).await.unwrap();
 
     let is_self_msg = &react_data.is_own(&_ctx.cache).await;
@@ -21,86 +23,109 @@ pub async fn responder(_ctx: Context, _added_reaction: Reaction) {
     }
 
     match emoji.as_str() {
-        "✍" => {
-            if !*a_bot_reacted_now && is_self_reacted {
-                react_data
-                    .delete_reaction_emoji(&_ctx.http, '✍')
-                    .await
-                    .unwrap();
+        // "✍" => {
+        //     if !*a_bot_reacted_now && is_self_reacted {
+        //         react_data
+        //             .delete_reaction_emoji(&_ctx.http, '✍')
+        //             .await
+        //             .unwrap();
 
-                let dbnode = Database::from("msgcache".to_string()).await;
-                // Use contentsafe options
-                let settings = {
-                    ContentSafeOptions::default()
-                        .clean_channel(false)
-                        .clean_role(true)
-                        .clean_user(true)
-                        .clean_everyone(true)
-                        .clean_here(true)
-                };
+        //         let dbnode = Database::from("msgcache".to_string()).await;
+        //         // Use contentsafe options
+        //         let settings = {
+        //             ContentSafeOptions::default()
+        //                 .clean_channel(false)
+        //                 .clean_role(true)
+        //                 .clean_user(true)
+        //                 .clean_everyone(true)
+        //                 .clean_here(true)
+        //         };
 
-                let content = content_safe(
-                    &_ctx.cache,
-                    dbnode.fetch_msg(_added_reaction.message_id).await,
-                    &settings,
-                )
-                .await;
+        //         let content = content_safe(
+        //             &_ctx.cache,
+        //             dbnode.fetch_msg(_added_reaction.message_id).await,
+        //             &settings,
+        //         )
+        //         .await;
 
-                react_data
-                    .reply(
-                        &_ctx.http,
-                        &content
-                            .replace(
-                                "---MSG_TYPE---",
-                                format!("Triggered: {} `||` Edited:", &reacted_user).as_str(),
-                            )
-                            .as_str()
-                            .substring(0, 2000),
-                    )
-                    .await
-                    .unwrap()
-                    .react(&_ctx.http, '🔃')
-                    .await
-                    .unwrap();
+        //         react_data
+        //             .reply(
+        //                 &_ctx.http,
+        //                 &content
+        //                     .replace(
+        //                         "---MSG_TYPE---",
+        //                         format!("Triggered: {} `||` Edited:", &reacted_user).as_str(),
+        //                     )
+        //                     .as_str()
+        //                     .substring(0, 2000),
+        //             )
+        //             .await
+        //             .unwrap()
+        //             .react(&_ctx.http, '🔃')
+        //             .await
+        //             .unwrap();
 
-                // let msg_content = &react_data.content;
-                // let edit_time = &react_data.edited_timestamp.unwrap().format("%H:%M:%S %p");
-                // let old_content = dbnode.fetch_msg(react_data.id).await;
-                // let new_content = format!(
-                //     "{}\n> Edited at: {}\n {}",
-                //     &msg_content, &edit_time, &old_content
-                // );
-                // dbnode.save_msg(&react_data.id, new_content).await;
-            }
-        }
+        //         // let msg_content = &react_data.content;
+        //         // let edit_time = &react_data.edited_timestamp.unwrap().format("%H:%M:%S %p");
+        //         // let old_content = dbnode.fetch_msg(react_data.id).await;
+        //         // let new_content = format!(
+        //         //     "{}\n> Edited at: {}\n {}",
+        //         //     &msg_content, &edit_time, &old_content
+        //         // );
+        //         // dbnode.save_msg(&react_data.id, new_content).await;
+        //     }
+        // }
 
         // Deleted message handlers and or listeners
         "📩" => {
-            if !*a_bot_reacted_now && is_self_reacted {
-                react_data
-                    .delete_reaction_emoji(&_ctx.http, '📩')
-                    .await
-                    .unwrap();
-
-                let dbnode = Database::from("delmsg_trigger".to_string()).await;
-
-                let content = dbnode.fetch_msg(_added_reaction.message_id).await.replace(
-                    "---MSG_TYPE---",
-                    format!("Triggered: {} `||` Deleted:", &reacted_user).as_str(),
-                );
-
-                react_data
-                    .reply(&_ctx.http, &content.as_str().substring(0, 2000))
+            if is_self_reacted {
+                let roles = &_added_reaction.member.unwrap().roles;
+                let is_owner = &_added_reaction
+                    .guild_id
+                    .unwrap()
+                    .to_partial_guild(&_ctx)
                     .await
                     .unwrap()
-                    .react(&_ctx.http, '🔃')
-                    .await
-                    .unwrap();
+                    .owner_id
+                    == &reacted_user.id;
+                let mut got_admin = false;
+
+                for role in roles {
+                    if role
+                        .to_role_cached(&_ctx.cache)
+                        .await
+                        .map_or(false, |r| r.has_permission(Permissions::ADMINISTRATOR))
+                    {
+                        got_admin = true;
+                        break;
+                    }
+                }
+                if got_admin || is_owner {
+                    react_data
+                        .delete_reaction_emoji(&_ctx.http, '📩')
+                        .await
+                        .unwrap();
+
+                    let dbnode = Database::from("delmsg_trigger".to_string()).await;
+
+                    let content = dbnode.fetch_msg(_added_reaction.message_id).await.replace(
+                        "---MSG_TYPE---",
+                        format!("Triggered: {} `||` Deleted:", &reacted_user).as_str(),
+                    );
+
+                    react_data
+                        .reply(&_ctx.http, &content.as_str().substring(0, 2000))
+                        .await
+                        .unwrap()
+                        .react(&_ctx.http, '🔃')
+                        .await
+                        .unwrap();
+                }
             }
         }
 
         "🔃" => {
-            if !*a_bot_reacted_now && *is_self_msg && is_self_reacted {
+            if *is_self_msg && is_self_reacted {
                 react_data
                     .delete_reaction_emoji(&_ctx.http, '🔃')
                     .await
@@ -127,20 +152,10 @@ pub async fn responder(_ctx: Context, _added_reaction: Reaction) {
         }
 
         "❎" => {
-            if !*a_bot_reacted_now && is_self_reacted && *is_self_msg {
+            if is_self_reacted && *is_self_msg {
                 react_data.delete(&_ctx.http).await.unwrap();
             }
         }
-        // "✅" => {
-        //     if dbg!(!*a_bot_reacted_now && *is_self_msg) {
-        //         println!("lol");
-        //         let thread = &react_data
-        //             .channel_id
-        //             .edit_thread(&_ctx.http, |t| t.archived(true))
-        //             .await
-        //             .unwrap();
-        //     }
-        // }
         _ => {}
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
This helps avoid confusion among users unfamiliar with this logging functionality.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->

## Release Notes
<!--
  Add entries for the CHANGELOG.md or "NONE" if there aren't any user facing changes.
  Each line becomes a separate entry.
  Format: [!<optional for breaking>] <description>
  Example: !basic auth is no longer supported
  See https://www.notion.so/gitpod/Release-Notes-513a74fdd23b4cb1b3b3aefb1d34a3e0
-->
```release-note
```

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->
