### PR TITLE
feat: Use ephemeral messages for bot button click responses

### DIFF
--- a/src/event/interaction_create/question_thread_suggestions.rs
+++ b/src/event/interaction_create/question_thread_suggestions.rs
@@ -5,8 +5,9 @@ use serenity::{
     client::Context,
     model::{
         application::{
-            component::ButtonStyle, interaction::message_component::MessageComponentInteraction,
-            interaction::InteractionResponseType,
+            component::ButtonStyle,
+            interaction::message_component::MessageComponentInteraction,
+            interaction::{InteractionResponseType, MessageFlags},
         },
         channel::ReactionType,
         prelude::component::Button,
@@ -35,6 +36,7 @@ pub async fn responder(mci: &MessageComponentInteraction, ctx: &Context) -> Resu
         mci.create_interaction_response(&ctx.http, |r| {
             r.kind(InteractionResponseType::ChannelMessageWithSource)
                 .interaction_response_data(|d| {
+                    d.flags(MessageFlags::EPHEMERAL);
                     d.content(format!("{}: {button_label}", &mci.user.mention()))
                         .components(|c| {
                             c.create_action_row(|a| {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes https://linear.app/gitpod/issue/COM-106/use-ephemeral-messages-for-optimus-bot-button-click-responses

## How to test
<!-- Provide steps to test this PR -->

## Documentation
<!--
Does this PR require updates to the documentation at www.gitpod.io/docs?
* Yes
  * 1. Please create a docs issue: https://github.com/gitpod-io/website/issues/new?labels=documentation&template=DOCS-NEW-FEATURE.yml&title=%5BDocs+-+New+Feature%5D%3A+%3Cyour+feature+name+here%3E
  * 2. Paste the link to the docs issue below this comment
* No
  * Are you sure? If so, nothing to do here.
-->

/hold
